### PR TITLE
[PKG-2191] umap-learn 0.5.3

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,8 +13,8 @@ source:
 
 build:
   number: 0
-  skip: true  # [win and py27 or win32]
-  script: {{ PYTHON }} -m pip install . --no-deps -vv
+  skip: true  # [py<36]
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
 requirements:
   build:
@@ -28,10 +28,9 @@ requirements:
     - python
     - setuptools
     - numpy >=1.17
-    - numba >=0.51.2
+    - numba >=0.49
     - scikit-learn >=0.22
-    - scipy >=1.3.1
-    - tbb >=2019.0
+    - scipy >=1.0
     - pynndescent >=0.5
     - tqdm
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,10 +23,10 @@ requirements:
   host:
     - python
     - setuptools
+    - wheel
     - pip
   run:
     - python
-    - setuptools
     - numpy >=1.17
     - numba >=0.49
     - scikit-learn >=0.22
@@ -35,11 +35,15 @@ requirements:
     - tqdm
 
 test:
+  requires:
+    - pip
   imports:
     - umap
+  commands:
+    - pip check
 
 about:
-  home: http://github.com/lmcinnes/umap
+  home: https://github.com/lmcinnes/umap
   license: BSD-2-Clause
   license_family: BSD
   license_file: {{ environ["RECIPE_DIR"] }}/LICENSE
@@ -52,6 +56,7 @@ about:
     runtime performacne than t-SNE and often preserves more global
     structure than t-SNE.
   dev_url: https://github.com/lmcinnes/umap
+  doc_url: https://umap-learn.readthedocs.io/en/latest/
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,8 @@ source:
 
 build:
   number: 0
-  skip: true  # [py<36]
+  # depends on numba not available for linux-s390x
+  skip: true  # [py<36 or s390x]
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
 requirements:


### PR DESCRIPTION
[PKG-2191]

- added as submodule in `aggregate`: there was a version `0.5.3` already in AnacondaRecipes, but it was not present as submodule in `aggregate`.
- updated a few dependencies (lowered their version according to https://github.com/lmcinnes/umap/blob/0.5.3/setup.py)
- skip for `[py<36]`, according to https://github.com/lmcinnes/umap/blob/0.5.3/setup.py
- skip platform `linux-s390x` because depends on `numba` not present in `linux-s390x` [see latest PR](https://github.com/AnacondaRecipes/numba-feedstock/pull/12/files)
- do not skip `win32` (we have only `win64`)
- doc_url: https://umap-learn.readthedocs.io/en/latest/
- other linter checks

[PKG-2191]: https://anaconda.atlassian.net/browse/PKG-2191?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
